### PR TITLE
Add suport for tinker 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php": "^7.2",
         "facade/ignition": "^1.0",
         "illuminate/support": "^5.8|^6.0",
-        "laravel/tinker": "^1.0",
+        "laravel/tinker": "^1.0|^2.0",
         "spatie/laravel-web-tinker": "^1.4"
     },
     "require-dev": {


### PR DESCRIPTION
Was trying to get the tinker tab working in Laravel 6, and I had recently updated tinker to v2.0.0 and it would not install due to tinker being on an "unsupported" version.

PR just adds support for the 2.x branch of tinker in composer.json as well as the 1.x branch.

[Changelog](https://github.com/laravel/tinker/releases/tag/v2.0.0) for v2.0.0 drops support for older PHP and Symfony versions and allows for Laravel 7.